### PR TITLE
Cache diffs

### DIFF
--- a/backend/models/Page.js
+++ b/backend/models/Page.js
@@ -22,15 +22,13 @@ var queryPath = function (pageName) {
 // there is an api option to return revisions starting at a given id:
 // *rvstartid* but it seems to be broken.
 var rmPreviousRevisions = function(current, lastRevisionIds) {
-  var newRevisions = current.filter(function(revision) {
+  return current.filter(function(revision) {
     var lastContainedInCurrent = lastRevisionIds.some(function(lastId) {
       return lastId === revision.revid;
     });
 
     return !lastContainedInCurrent;
   });
-
-  return newRevisions;
 };
 
 var pageData = function(body, lastRevisionIds) {

--- a/backend/models/Revision.js
+++ b/backend/models/Revision.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var DiffFormatter = require('../helpers/DiffFormatter');
 var WikipediaHelper = require('../helpers/WikipediaHelper');
 var log = require('../config/log').createLoggerForFile(__filename);
 
@@ -10,22 +9,8 @@ module.exports.find = function (revisionIDs, callback) {
     revisionIDs = [ revisionIDs ];
   }
 
-  WikipediaHelper.getAndCacheRevisions(revisionIDs).then(function(blobs) {
-    if (blobs.length === 2) {
-      var prevHtml = blobs[1];
-      var revHtml = blobs[0];
-
-      return new DiffFormatter(revHtml, prevHtml).generateDiff();
-    } else {
-      return {
-        content: blobs[0],
-        added: 0,
-        removed: 0
-      };
-    }
-  }).then(function(data) {
+  WikipediaHelper.getRevisionsDiff(revisionIDs).then(function(data) {
     data.content = PageProcessor.process(data.content);
-
     callback(undefined, data);
   }).catch(function(err) {
     log.error(err);


### PR DESCRIPTION
If a diff has been processed before, we save a cached copy and fetch that on subsequent requests.

Best case scenario, we end up saving one call to the cache server and the overhead that comes with processing the diff using the DiffFormater library (which may not be much, but hey, it's something).
