### PR TITLE
Resolve issue #273: Wash button does not display error message while clicking without entering data in search field

### DIFF
--- a/frontend/scripts/controllers/home.js
+++ b/frontend/scripts/controllers/home.js
@@ -13,6 +13,11 @@ angular.module('wikiwash').controller('HomeController',
     });
 
     $scope.submit = function() {
+      if( ! $scope.pageName) {
+        $scope.invalidPageName = true;
+        return;
+      }
+      $scope.invalidPageName = false;
       $location.path(pageParser.getPageName($scope.pageName));
     };
     

--- a/frontend/styles/application.scss
+++ b/frontend/styles/application.scss
@@ -3,6 +3,8 @@
 @import "bourbon";
 @import "font-awesome";
 
+$error: #F44;
+
 * {
   font-family: 'Source Sans Pro', sans-serif;
 }
@@ -120,6 +122,9 @@ span.light {
   @media (max-width: 600px){
     margin-top: 20px;
   }
+  .error {
+    color: $error;
+  }
 }
 
 .search-splash input.bar {
@@ -138,6 +143,10 @@ span.light {
   }
   &:focus{
     border: 2px solid #00A7CE;
+    outline: 0;
+  }
+  &.invalid{
+    border: 2px solid $error;
     outline: 0;
   }
 }

--- a/frontend/views/partials/search.jade
+++ b/frontend/views/partials/search.jade
@@ -12,7 +12,9 @@
   .search-splash
     form(ng-submit="search()")
       input.button(type='submit' value='WASH' ng-click='submit()')
-      input.bar(type="search" placeholder="Paste a Wikipedia URL to wash" ng-model='pageName' ng-keyup="$event.keyCode == 13 && submit()")
+      input.bar(type="search" placeholder="Paste a Wikipedia URL to wash" ng-model='pageName' ng-keyup="$event.keyCode == 13 && submit()" ng-class="{'invalid': invalidPageName && pageName.length == 0}")
+    .error(ng-show="invalidPageName")
+      p Search field can not be left blank
 
   .search-suggestions(ng-if='suggestions.length > 0')
     p Not sure which article to wash? Try looking at Wikipedia's most-read articles from the last hour:


### PR DESCRIPTION
Resolves issue #273 

Color being used to display error message is #F44 - in case another color is desired, change the $error variable in the application.scss file (L#6). Same color is used for the text shown below as well as the input border. Input border color disappears when text is entered (whether the wash button has been clicked or not).

![wikiwash](https://cloud.githubusercontent.com/assets/2471622/17979170/4d0afd7c-6ac7-11e6-9cfb-b40ea5802ba4.png)
